### PR TITLE
fixing PeerConnectionHandler

### DIFF
--- a/src/main/scala/scorex/core/network/SyncTracker.scala
+++ b/src/main/scala/scorex/core/network/SyncTracker.scala
@@ -92,6 +92,10 @@ class SyncTracker(nvsRef: ActorRef,
   private def outdatedPeers(): Seq[ConnectedPeer] =
     lastSyncSentTime.filter(t => (timeProvider.time() - t._2).millis > maxInterval()).keys.toSeq
 
+
+  def peersByStatus: Map[HistoryComparisonResult, Iterable[ConnectedPeer]] =
+    statuses.groupBy(_._2).mapValues(_.keys).view.force
+
   private def numOfSeniors(): Int = statuses.count(_._2 == Older)
 
   /**


### PR DESCRIPTION
Problem: false positive peer bans, ie. peers are getting banned even though they communicate properly.

Explanation: 
Logic of this whole incoming data deserialization is as follows : 
 1. ByteString is received 
 2. if BS length is less than message length, keep on reading next BS as we have not enough bytes yet
 3. otherwise try to deserialize it into a message

The bug is caused by the fact that we are testing for `magic` and grabbing `msgCode` before checking the length, which means it fails (incorrectly) at time when not enough bytes is read to be able to deserialize it into a message.

Fix outcome: 
No bans happen now and more peers are connected, tested on Ergo.