### PR TITLE
handle db errors at higher level

### DIFF
--- a/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
+++ b/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
@@ -474,7 +474,7 @@ class HybridHistory(val storage: HistoryStorage,
     chainBack(storage.bestPosBlock, isGenesis).get.map(_._2).map(encoder.encodeId).mkString(",")
   }
 
-  override def reportModifierIsValid(modifier: HybridBlock): HybridHistory = {
+  override def reportModifierIsValid(modifier: HybridBlock): Try[HybridHistory] = Try {
     storage.updateValidity(modifier, Valid)
     storage.update(modifier, None, isBest = true)
 
@@ -482,8 +482,8 @@ class HybridHistory(val storage: HistoryStorage,
   }
 
   override def reportModifierIsInvalid(modifier: HybridBlock,
-                                       progressInfo: ProgressInfo[HybridBlock]): (HybridHistory,
-    ProgressInfo[HybridBlock]) = {
+                                       progressInfo: ProgressInfo[HybridBlock]): Try[(HybridHistory,
+    ProgressInfo[HybridBlock])] = Try {
     storage.updateValidity(modifier, Invalid)
 
     new HybridHistory(storage, settings, validators, statsLogger, timeProvider) ->

--- a/src/main/scala/scorex/core/NodeViewHolder.scala
+++ b/src/main/scala/scorex/core/NodeViewHolder.scala
@@ -222,14 +222,18 @@ trait NodeViewHolder[TX <: Transaction, PMOD <: PersistentNodeViewModifier]
 
     stateToApplyTry match {
       case Success(stateToApply) =>
-        val stateUpdateInfo = applyState(history, stateToApply, suffixTrimmed, progressInfo)
-
-        stateUpdateInfo.failedMod match {
-          case Some(_) =>
-            @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
-            val alternativeProgressInfo = stateUpdateInfo.alternativeProgressInfo.get
-            updateState(stateUpdateInfo.history, stateUpdateInfo.state, alternativeProgressInfo, stateUpdateInfo.suffix)
-          case None => (stateUpdateInfo.history, Success(stateUpdateInfo.state), stateUpdateInfo.suffix)
+        applyState(history, stateToApply, suffixTrimmed, progressInfo) match {
+          case Success(stateUpdateInfo) =>
+            stateUpdateInfo.failedMod match {
+              case Some(_) =>
+                @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+                val alternativeProgressInfo = stateUpdateInfo.alternativeProgressInfo.get
+                updateState(stateUpdateInfo.history, stateUpdateInfo.state, alternativeProgressInfo, stateUpdateInfo.suffix)
+              case None =>
+                (stateUpdateInfo.history, Success(stateUpdateInfo.state), stateUpdateInfo.suffix)
+            }
+          case Failure(ex) =>
+            (history, Failure(ex), suffixTrimmed)
         }
       case Failure(e) =>
         log.error("Rollback failed: ", e)
@@ -239,34 +243,30 @@ trait NodeViewHolder[TX <: Transaction, PMOD <: PersistentNodeViewModifier]
     }
   }
 
-  protected def applyState(history: HIS,
+  private def applyState(history: HIS,
                            stateToApply: MS,
                            suffixTrimmed: IndexedSeq[PMOD],
-                           progressInfo: ProgressInfo[PMOD]): UpdateInformation = {
+                           progressInfo: ProgressInfo[PMOD]): Try[UpdateInformation] = {
     val updateInfoSample = UpdateInformation(history, stateToApply, None, None, suffixTrimmed)
-    progressInfo.toApply.foldLeft(updateInfoSample) { case (updateInfo, modToApply) =>
-      if (updateInfo.failedMod.isEmpty) {
-        updateInfo.state.applyModifier(modToApply) match {
-          case Success(stateAfterApply) =>
-            history.reportModifierIsValid(modToApply) match {
-              case Success(newHis) =>
+    progressInfo.toApply.foldLeft[Try[UpdateInformation]](Success(updateInfoSample)) {
+      case (f@Failure(ex), _) =>
+        log.error("Reporting modifier failed", ex)
+        f
+      case (success@Success(updateInfo), modToApply) =>
+        if (updateInfo.failedMod.isEmpty) {
+          updateInfo.state.applyModifier(modToApply) match {
+            case Success(stateAfterApply) =>
+              history.reportModifierIsValid(modToApply).map { newHis =>
                 context.system.eventStream.publish(SemanticallySuccessfulModifier(modToApply))
                 UpdateInformation(newHis, stateAfterApply, None, None, updateInfo.suffix :+ modToApply)
-              case Failure(t) =>
-                log.error("Applying valid modifier to history failed", t)
-                UpdateInformation(history, updateInfo.state, Some(modToApply), None, updateInfo.suffix)
-            }
-          case Failure(e) =>
-            history.reportModifierIsInvalid(modToApply, progressInfo) match {
-              case Success((newHis, newProgressInfo)) =>
+              }
+            case Failure(e) =>
+              history.reportModifierIsInvalid(modToApply, progressInfo).map { case (newHis, newProgressInfo) =>
                 context.system.eventStream.publish(SemanticallyFailedModification(modToApply, e))
                 UpdateInformation(newHis, updateInfo.state, Some(modToApply), Some(newProgressInfo), updateInfo.suffix)
-              case Failure(t) =>
-                log.error("Applying invalid modifier to history failed", t)
-                UpdateInformation(history, updateInfo.state, Some(modToApply), None, updateInfo.suffix)
-            }
-        }
-      } else updateInfo
+              }
+          }
+        } else success
     }
   }
 
@@ -304,8 +304,8 @@ trait NodeViewHolder[TX <: Transaction, PMOD <: PersistentNodeViewModifier]
 
               case Failure(e) =>
                 log.warn(s"Can`t apply persistent modifier (id: ${pmod.encodedId}, contents: $pmod) to minimal state", e)
+                // not publishing SemanticallyFailedModification as this is an internal error
                 updateNodeView(updatedHistory = Some(newHistory))
-                context.system.eventStream.publish(SemanticallyFailedModification(pmod, e))
             }
           } else {
             requestDownloads(progressInfo)

--- a/src/main/scala/scorex/core/NodeViewHolder.scala
+++ b/src/main/scala/scorex/core/NodeViewHolder.scala
@@ -163,7 +163,7 @@ trait NodeViewHolder[TX <: Transaction, PMOD <: PersistentNodeViewModifier]
     }
   }
 
-  private def requestDownloads(pi: ProgressInfo[PMOD]): Unit =
+  protected def requestDownloads(pi: ProgressInfo[PMOD]): Unit =
     pi.toDownload.foreach { case (tid, id) =>
       context.system.eventStream.publish(DownloadRequest(tid, id))
     }
@@ -206,7 +206,7 @@ trait NodeViewHolder[TX <: Transaction, PMOD <: PersistentNodeViewModifier]
    **/
 
   @tailrec
-  private def updateState(history: HIS,
+  protected final def updateState(history: HIS,
                           state: MS,
                           progressInfo: ProgressInfo[PMOD],
                           suffixApplied: IndexedSeq[PMOD]): (HIS, Try[MS], Seq[PMOD]) = {

--- a/src/main/scala/scorex/core/consensus/History.scala
+++ b/src/main/scala/scorex/core/consensus/History.scala
@@ -33,7 +33,7 @@ trait History[PM <: PersistentNodeViewModifier, SI <: SyncInfo, HT <: History[PM
     * @param modifier - valid modifier
     * @return modified history
     */
-  def reportModifierIsValid(modifier: PM): HT
+  def reportModifierIsValid(modifier: PM): Try[HT]
 
   /**
     * Report that modifier is invalid from other nodeViewHolder components point of view
@@ -42,7 +42,7 @@ trait History[PM <: PersistentNodeViewModifier, SI <: SyncInfo, HT <: History[PM
     * @param progressInfo - what suffix failed to be applied because of an invalid modifier
     * @return modified history and new progress info
     */
-  def reportModifierIsInvalid(modifier: PM, progressInfo: ProgressInfo[PM]): (HT, ProgressInfo[PM])
+  def reportModifierIsInvalid(modifier: PM, progressInfo: ProgressInfo[PM]): Try[(HT, ProgressInfo[PM])]
 
 
   /**

--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -203,7 +203,7 @@ class NetworkController(settings: NetworkSettings,
       filterConnections(Broadcast, Version.initial).foreach { connectedPeer =>
         connectedPeer.handlerRef ! CloseConnection
       }
-      self ! Unbind
+      tcpManager ! Unbind
       context stop self
   }
 

--- a/testkit/src/main/scala/scorex/testkit/properties/HistoryTests.scala
+++ b/testkit/src/main/scala/scorex/testkit/properties/HistoryTests.scala
@@ -53,7 +53,7 @@ trait HistoryTests[TX <: Transaction, PM <: PersistentNodeViewModifier, SI <: Sy
   property(propertyNameGenerator("report semantically validation after appending valid modifier")) {
     forAll(generatorWithValidModifier) { case (h, m) =>
       h.append(m)
-      h.reportModifierIsValid(m)
+      h.reportModifierIsValid(m).get
       h.isSemanticallyValid(m.id) shouldBe Valid
     }
   }


### PR DESCRIPTION
@kushti This is the most important part to review. `reportModifierIsValid` and `reportModifierIsInvalid` now return `Try` so this is the "higher level" place where we propagated the DB errors to. I did not publish any event as this is neither `semantically` nor `syntactically` failed modification, it just cannot be persisted. 

It differs as now DB errors leads to returning : 
```
                UpdateInformation(history, updateInfo.state, Some(modToApply), None, updateInfo.suffix)
```
which would lead to another `updateState` call which is probably wrong, it is just to demonstrate that we are handling that effect now.